### PR TITLE
style(components): 移除侧边栏 logo 文本

### DIFF
--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -43,7 +43,7 @@ const Sidebar = () => {
       >
         {/* Header */}
         <div className="p-4 flex items-center justify-between border-b ">
-          {!isCollapsed && <h1 className="text-xl font-bold">Logo</h1>}
+          {!isCollapsed && <h1 className="text-xl font-bold"> </h1>}
           <button
             onClick={toggleSidebar}
             className="text-gray-400 hover:text-white focus:outline-none"


### PR DESCRIPTION
移除了侧边栏头部的 "Logo" 文本，替换为一个空的<h1> 标签。这个修改可能是为了在侧边栏未折叠时留出更多空间，或者为后续添加自定义 logo做准备。